### PR TITLE
Reporting of failed tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,6 @@ export default function () {
                     '\' message=\'' + 'Test Failed' +
                     '\' captureStandardOutput=\'true\' ' +
                     'details=\'' + escape(this.renderErrors(testRunInfo.errs)) + '\']').newline();
-                return;
 
             }
             this.write('##teamcity[testFinished name=\'' + escape(name) + '\' duration=\'' + testRunInfo.durationMs + '\']').newline();

--- a/test/data/report-without-colors
+++ b/test/data/report-without-colors
@@ -7,6 +7,7 @@ Starting test run!
 ##teamcity[testFinished name='First test in first fixture' duration='74000']
 ##teamcity[testStarted name='Second test in first fixture']
 ##teamcity[testFailed name='Second test in first fixture' message='Test Failed' captureStandardOutput='true' details='|nError on page "http://example.org":|n|nSome error|n|nBrowser: Chrome 41.0.2227 / Mac OS X 10.10.1|nScreenshot: /screenshots/1445437598847/errors|n|n   1 ||var createCallsiteRecord = require (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n|n|nThe specified selector does not match any element in the DOM tree.|n|nBrowser: Firefox 47 / Mac OS X 10.10.1|n|n   1 ||var createCallsiteRecord = require (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n|n']
+##teamcity[testFinished name='Second test in first fixture' duration='74000']
 ##teamcity[testStarted name='Third test in first fixture']
 ##teamcity[testFinished name='Third test in first fixture' duration='74000']
 ##teamcity[testSuiteFinished name='First fixture']
@@ -21,6 +22,7 @@ Starting test run!
 ##teamcity[testSuiteStarted name='Third fixture']
 ##teamcity[testStarted name='First test in third fixture']
 ##teamcity[testFailed name='First test in third fixture' message='Test Failed' captureStandardOutput='true' details='|n- Error in beforeEach hook -|nThe specified selector does not match any element in the DOM tree.|n|nBrowser: Firefox 47 / Mac OS X 10.10.1|n|n   1 ||var createCallsiteRecord = require (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n   at Object.<anonymous> (some-file:1:1)|n|n']
+##teamcity[testFinished name='First test in third fixture' duration='74000']
 ##teamcity[testSuiteFinished name='Third fixture']
 Test Run Completed:
     End Time: Thu Jan 01 1970 00:15:25 GMT+0000 (UTC)

--- a/test/test.js
+++ b/test/test.js
@@ -10,3 +10,11 @@ it('Should produce report without colors', function () {
     expected = normalizeNewline(expected).trim();
     assert.strictEqual(report, expected);
 });
+
+it('Should produce `testFinished` message for failed test', function () {
+    var finishedMessage = "##teamcity[testFinished name='Second test in first fixture' duration='74000']";
+    var report          = createReport(false);
+    report = normalizeNewline(report).trim();
+    var containsFinishedMessage = report.indexOf(finishedMessage) !== -1;
+    assert.ok(containsFinishedMessage);
+});


### PR DESCRIPTION
We experienced a problem: tests subsequent to a failed test are reported nested in it.
TeamCity docs state what `testFailed` message should be placed inside `testStarted`\ `testFinished` pair (https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-Nestedtestreporting).
@nirsky